### PR TITLE
Fix SSE address format handling to prevent double colons

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,13 +48,24 @@ func main() {
 		return
 	}
 
+	// Format address for SSE transport
+	var formattedAddr string
+	if *transportType == "sse" {
+		// If addr doesn't start with ":", add it
+		if !strings.HasPrefix(*addr, ":") {
+			formattedAddr = ":" + *addr
+		} else {
+			formattedAddr = *addr
+		}
+	}
+
 	// Create transport
 	var t mcp.Transport
 	switch *transportType {
 	case "stdio":
 		t = transport.NewSTDIOTransport()
 	case "sse":
-		t = transport.NewSSETransport(":" + *addr)
+		t = transport.NewSSETransport(formattedAddr)
 	default:
 		log.Fatalf("Unknown transport type: %s", *transportType)
 	}


### PR DESCRIPTION
## Problem

The Docker container was failing with the error:
```
SSE server error: listen tcp: address ::8080: too many colons in address
```

This occurred because our code was always adding a colon prefix to the address, even when the address might already have one, resulting in malformed addresses like `::8080`.

## Solution

Updated the SSE address formatting logic to match the framework conventions from `mcp-server-framework v1.0.0`:

- Check if the address already starts with `:` before adding a colon prefix
- Support both `8080` and `:8080` input formats
- Prevent double colon issues in Docker containers

## Changes

- Added proper address formatting logic in `main.go`
- Follows the exact pattern used in the framework's example code
- Maintains backward compatibility with existing usage

## Testing

✅ Tested with `-addr=8080` → formats to `:8080`  
✅ Tested with `-addr=:8080` → keeps as `:8080`  
✅ Both formats start SSE server successfully without errors

This fix ensures the Docker container will work correctly and matches the framework's recommended patterns.